### PR TITLE
Update workflow: Trigger manually

### DIFF
--- a/.github/workflows/nuget_publish.yml
+++ b/.github/workflows/nuget_publish.yml
@@ -1,7 +1,13 @@
-name: publish to nuget
+name: Publish to NuGet
 on:
   push:
     branches: [ "main" ] # Default release branch
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - "**/*.md"
+      - "**/*.gitignore"
+  workflow_dispatch:
 jobs:
   publish:
     name: Build, Pack & Publish
@@ -17,7 +23,7 @@ jobs:
           dotnet-version: ${{ matrix.dotnet-version }}
           dotnet-quality: ga
       # Publish
-      - name: publish on version change
+      - name: Publish on Version Change
         id: publish_nuget
         uses: Rebel028/publish-nuget@v2.8.0
         with:
@@ -43,7 +49,7 @@ jobs:
           TAG_FORMAT: v*
 
           # API key to authenticate with NuGet server, or a token, issued for GITHUB_USER if you use GPR
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_KEY: ${{ secrets.NUGET_API_KEY }}
 
           # NuGet server uri hosting the packages, defaults to https://api.nuget.org
           # NUGET_SOURCE: https://api.nuget.org


### PR DESCRIPTION
The secret name are misspelled, so the action to publish the package to NuGet aren't triggered.
This commit added `workflow_dispatch` to enable manually trigger the workflow.